### PR TITLE
Config changes for higher loads

### DIFF
--- a/helm/elasticsearch/templates/configmap.yaml
+++ b/helm/elasticsearch/templates/configmap.yaml
@@ -1,5 +1,3 @@
-{{- if .Values.esConfig or .Values.volumeClaimTemplate }}
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,14 +10,13 @@ metadata:
 data:
 {{- if .Values.esConfig }}
 {{- range $path, $config := .Values.esConfig }}
-  {{ $path }}: |
-{{ $config | indent 4 -}}
+  {{ $path }}: |-
+{{ $config | indent 4 }}
 {{- end -}}
-
+{{- end -}}
 {{- if .Values.volumeClaimTemplate }}
-{{- range $path, $config := .Values.volumeClaimTemplate }}
-  {{ $path }}: |
-{{ $config | indent 4 -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- range $path, $volume := .Values.volumeClaimTemplate }}
+  {{ $path }}: |-
+{{ toYaml $volume | indent 6 }}
+{{- end }}
+{{- end }}

--- a/helm/elasticsearch/templates/configmap.yaml
+++ b/helm/elasticsearch/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.esConfig }}
+{{- if .Values.esConfig or .Values.volumeClaimTemplate }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -10,8 +10,16 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ template "uname" . }}"
 data:
+{{- if .Values.esConfig }}
 {{- range $path, $config := .Values.esConfig }}
   {{ $path }}: |
 {{ $config | indent 4 -}}
+{{- end -}}
+
+{{- if .Values.volumeClaimTemplate }}
+{{- range $path, $config := .Values.volumeClaimTemplate }}
+  {{ $path }}: |
+{{ $config | indent 4 -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/elasticsearch/values.yaml
+++ b/helm/elasticsearch/values.yaml
@@ -44,9 +44,9 @@ resources:
     memory: "8Gi"
   limits:
     cpu: "4000m"
-    memory: "8Gi"
+    memory: "12Gi"
 
-esJavaOpts: "-Xmx12g -Xms12g"
+esJavaOpts: "-Xmx8g -Xms8g"
 
 networkHost: "0.0.0.0"
 

--- a/helm/elasticsearch/values.yaml
+++ b/helm/elasticsearch/values.yaml
@@ -54,8 +54,7 @@ persistence:
   annotations: {}
 
 volumeClaimTemplate:
-  accessModes: ["ReadWriteMany"]
-  storageClassName: af-standard
+  accessModes: ["ReadWriteOnce"]
   resources:
     requests:
       storage: 500Gi

--- a/helm/elasticsearch/values.yaml
+++ b/helm/elasticsearch/values.yaml
@@ -54,7 +54,8 @@ persistence:
   annotations: {}
 
 volumeClaimTemplate:
-  accessModes: ["ReadWriteOnce"]
+  accessModes: [ "ReadWriteOnce" ]
+  storageClassName: "default"
   resources:
     requests:
       storage: 500Gi

--- a/helm/elasticsearch/values.yaml
+++ b/helm/elasticsearch/values.yaml
@@ -43,10 +43,10 @@ resources:
     cpu: "100m"
     memory: "8Gi"
   limits:
-    cpu: "1000m"
+    cpu: "4000m"
     memory: "8Gi"
 
-esJavaOpts: "-Xmx4g -Xms4g"
+esJavaOpts: "-Xmx12g -Xms12g"
 
 networkHost: "0.0.0.0"
 
@@ -54,7 +54,8 @@ persistence:
   annotations: {}
 
 volumeClaimTemplate:
-  accessModes: [ "ReadWriteOnce" ]
+  accessModes: ["ReadWriteMany"]
+  storageClassName: af-standard
   resources:
     requests:
       storage: 500Gi
@@ -75,7 +76,7 @@ fsGroup: 1000
 
 readinessProbe:
   failureThreshold: 3
-  initialDelaySeconds: 10
+  initialDelaySeconds: 60
   periodSeconds: 10
   successThreshold: 3
   timeoutSeconds: 5


### PR DESCRIPTION
Changes required from Telekom to facilitate their load accordingly to the tests they performed with own implementation.

Changes:
- 1 cpu and 4g heapspace are not enough - 4cpu needed at start for re-indexing, 12g of heapspace(might be bit too much)
- use azure file instead of disk to prevent impacting the node on failure, happens rarely but if does everything on the node is impacted. Drawback: it's slow
- InitialDelaySeconds: 1 minute - might increase to 2 - takes time to start up sometimes is what they claim